### PR TITLE
Add Stripe to MultiMarketplaceOrchestratorExample

### DIFF
--- a/DurableFunctionOrchestratorExample/DurableFunctionOrchestratorExample.csproj
+++ b/DurableFunctionOrchestratorExample/DurableFunctionOrchestratorExample.csproj
@@ -6,12 +6,12 @@
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.3.0" />
-		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.2" />
+		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.8.0" />
+		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
-		<PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.2" />
-		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.1" />
+		<PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
+		<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
 		<PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" />
 	</ItemGroup>

--- a/MultiMarketplaceOrchestratorExample/MultiMarketplaceOrchestrator.cs
+++ b/MultiMarketplaceOrchestratorExample/MultiMarketplaceOrchestrator.cs
@@ -4,6 +4,7 @@ using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 using MultiMarketplaceOrchestratorExample.AWS;
 using MultiMarketplaceOrchestratorExample.Azure;
+using MultiMarketplaceOrchestratorExample.Stripe;
 using Orchestrator.Core;
 using Orchestrator.Core.Contracts;
 using Orchestrator.Core.Models;
@@ -53,9 +54,17 @@ namespace MultiMarketplaceOrchestratorExample
                     (Marketplace.Azure,SubscriptionEvent.Suspend) => nameof(AzureSuspendFunction.AzureSuspend),
                     (Marketplace.Azure, SubscriptionEvent.Reinstate) => nameof(AzureReinstateFunction.AzureReinstate),
                     (Marketplace.Azure,SubscriptionEvent.Delete) => nameof(AzureDeleteFunction.AzureDelete),
+                    
                     (Marketplace.Aws, SubscriptionEvent.Create) => nameof(AwsCreateFunction.AwsCreate),
                     (Marketplace.Aws, SubscriptionEvent.Update) => nameof(AwsUpdateFunction.AwsUpdate),
                     (Marketplace.Aws, SubscriptionEvent.Delete) => nameof(AwsDeleteFunction.AwsDelete),
+
+                    (Marketplace.Stripe, SubscriptionEvent.Create) => nameof(StripeCreateFunction.StripeCreate),
+                    (Marketplace.Stripe, SubscriptionEvent.Update) => nameof(StripeUpdateFunction.StripeUpdate),
+                    (Marketplace.Stripe, SubscriptionEvent.Suspend) => nameof(StripeSuspendFunction.StripeSuspend),
+                    (Marketplace.Stripe, SubscriptionEvent.Reinstate) => nameof(StripeReinstateFunction.StripeReinstate),
+                    (Marketplace.Stripe, SubscriptionEvent.Delete) => nameof(StripeDeleteFunction.StripeDelete),
+
                     _ => throw new NotImplementedException("No handler for orchestration event.")
                 };
 

--- a/MultiMarketplaceOrchestratorExample/MultiMarketplaceOrchestratorExample.csproj
+++ b/MultiMarketplaceOrchestratorExample/MultiMarketplaceOrchestratorExample.csproj
@@ -11,12 +11,12 @@
     <!-- Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4. -->
     <!-- <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" /> -->
     <!-- <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" /> -->
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.1.7" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
-	<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.22.2" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.8.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.5" />
+	<PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Orchestrator.Core\Orchestrator.Core.csproj" />
@@ -33,5 +33,8 @@
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Stripe\" />
   </ItemGroup>
 </Project>

--- a/MultiMarketplaceOrchestratorExample/MultiMarketplaceOrchestratorExample.csproj
+++ b/MultiMarketplaceOrchestratorExample/MultiMarketplaceOrchestratorExample.csproj
@@ -34,7 +34,4 @@
   <ItemGroup>
     <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Stripe\" />
-  </ItemGroup>
 </Project>

--- a/MultiMarketplaceOrchestratorExample/Stripe/StripeCreateFunction.cs
+++ b/MultiMarketplaceOrchestratorExample/Stripe/StripeCreateFunction.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Azure.Functions.Worker;
+using Orchestrator.Core;
+using Orchestrator.Core.Models;
+
+namespace MultiMarketplaceOrchestratorExample.Stripe
+{
+    public static class StripeCreateFunction
+    {
+        [Function(nameof(StripeCreate))]
+        public static OrchestrationResultModel StripeCreate([ActivityTrigger] StripeOrchestrationActionModel orchestrationAction)
+        {
+            //Call your orchestration functions here to create your instances and generate a url for a user to log in to
+            return orchestrationAction.CreateSuccessResult(new Uri("https://mywebsite.com"));
+        }
+    }
+}

--- a/MultiMarketplaceOrchestratorExample/Stripe/StripeDeleteFunction.cs
+++ b/MultiMarketplaceOrchestratorExample/Stripe/StripeDeleteFunction.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Azure.Functions.Worker;
+using Orchestrator.Core;
+using Orchestrator.Core.Models;
+
+namespace MultiMarketplaceOrchestratorExample.Stripe
+{
+    public static class StripeDeleteFunction
+    {
+        [Function(nameof(StripeDelete))]
+        public static OrchestrationResultModel StripeDelete([ActivityTrigger] StripeOrchestrationActionModel orchestrationAction)
+        {
+            //Call your orchestration functions here to remove any instances and user logins
+            return orchestrationAction.CreateSuccessResult(new Uri("about:blank"));
+        }
+    }
+}

--- a/MultiMarketplaceOrchestratorExample/Stripe/StripeReinstateFunction.cs
+++ b/MultiMarketplaceOrchestratorExample/Stripe/StripeReinstateFunction.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Azure.Functions.Worker;
+using Orchestrator.Core;
+using Orchestrator.Core.Models;
+
+namespace MultiMarketplaceOrchestratorExample.Stripe
+{
+    public static class StripeReinstateFunction
+    {
+        [Function(nameof(StripeReinstate))]
+        public static OrchestrationResultModel StripeReinstate([ActivityTrigger] StripeOrchestrationActionModel orchestrationAction)
+        {
+            //Call your orchestration functions here to remove the suspended state
+            return orchestrationAction.CreateSuccessResult(new Uri("https://mywebsite.com"));
+        }
+    }
+}

--- a/MultiMarketplaceOrchestratorExample/Stripe/StripeSuspendFunction.cs
+++ b/MultiMarketplaceOrchestratorExample/Stripe/StripeSuspendFunction.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Azure.Functions.Worker;
+using Orchestrator.Core;
+using Orchestrator.Core.Models;
+
+namespace MultiMarketplaceOrchestratorExample.Stripe
+{
+    public static class StripeSuspendFunction
+    {
+        [Function(nameof(StripeSuspend))]
+        public static OrchestrationResultModel StripeSuspend([ActivityTrigger] StripeOrchestrationActionModel orchestrationAction)
+        {
+            //Call your orchestration functions here to put instances into a suspended state
+            return orchestrationAction.CreateSuccessResult(new Uri("https://mywebsite.com"));
+        }
+    }
+}

--- a/MultiMarketplaceOrchestratorExample/Stripe/StripeUpdateFunction.cs
+++ b/MultiMarketplaceOrchestratorExample/Stripe/StripeUpdateFunction.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Azure.Functions.Worker;
+using Orchestrator.Core;
+using Orchestrator.Core.Models;
+
+namespace MultiMarketplaceOrchestratorExample.Stripe
+{
+    public static class StripeUpdateFunction
+    {
+        [Function(nameof(StripeUpdate))]
+        public static OrchestrationResultModel StripeUpdate([ActivityTrigger] StripeOrchestrationActionModel orchestrationAction)
+        {
+            //Call your orchestration functions here to update any instances and send potentially new url
+            return orchestrationAction.CreateSuccessResult(new Uri("https://mywebsite.com"));
+        }
+    }
+}

--- a/MultiMarketplaceOrchestratorExample/host.json
+++ b/MultiMarketplaceOrchestratorExample/host.json
@@ -1,12 +1,20 @@
 {
-    "version": "2.0",
-    "logging": {
-        "applicationInsights": {
-            "samplingSettings": {
-                "isEnabled": true,
-                "excludedTypes": "Request"
-            },
-            "enableLiveMetricsFilters": true
-        }
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      },
+      "enableLiveMetricsFilters": true
     }
+  },
+  "extensions": {
+    "durableTask": {
+      "tracing": {
+        "distributedTracingEnabled": true,
+        "version": "V2"
+      }
+    }
+  }
 }

--- a/Orchestrator.Core/Converters/OrchestrationActionModelConverter.cs
+++ b/Orchestrator.Core/Converters/OrchestrationActionModelConverter.cs
@@ -27,6 +27,7 @@ namespace Orchestrator.Core.Converters
             {
                 "Azure" => JsonSerializer.Deserialize<AzureOrchestrationActionModel>(jsonDoc, options),
                 "Aws" => JsonSerializer.Deserialize<AwsOrchestrationActionModel>(jsonDoc, options),
+                "Stripe" => JsonSerializer.Deserialize<StripeOrchestrationActionModel>(jsonDoc, options),
                 _ => throw new JsonException($"Unknown OriginatingMarketplace: {originatingMarketplace}")
             };
 

--- a/Orchestrator.Core/Models/OrchestrationActionBaseModel.cs
+++ b/Orchestrator.Core/Models/OrchestrationActionBaseModel.cs
@@ -103,6 +103,7 @@ namespace Orchestrator.Core.Models
     public enum Marketplace
     {
         Azure,
-        Aws
+        Aws,
+        Stripe
     }
 }

--- a/Orchestrator.Core/Models/StripeOrchestrationActionModel.cs
+++ b/Orchestrator.Core/Models/StripeOrchestrationActionModel.cs
@@ -1,0 +1,72 @@
+﻿
+using System.Collections.Generic;
+
+namespace Orchestrator.Core.Models
+{
+    public class StripeOrchestrationActionModel : OrchestrationActionBaseModel
+    {
+        public override Marketplace OriginatingMarketplace => Marketplace.Stripe;
+
+        /// <summary>
+        /// List of items on the subscription
+        /// </summary>
+        public List<StripeItemModel> Items { get; set; } = [];
+
+        /// <summary>
+        /// Custom fields entered on the Stripe checkout form.
+        /// Will be empty if no custom fields are defined.
+        /// </summary>
+        public List<StripeCustomFieldModel> CustomStripeFields { get; set; } = [];
+    }
+
+    /// <summary>
+    /// Model representing the items on a Stripe subscription.
+    /// An item represents a certain number of products purchased at a certain price.
+    /// </summary>
+    public class StripeItemModel
+    {
+        /// <summary>
+        /// Id of the line item for this subscription
+        /// </summary>
+        public required string Id { get; set; }
+
+        /// <summary>
+        /// The Id of the Price associated with this item
+        /// </summary>
+        public required string PriceId { get; set; }
+
+        /// <summary>
+        /// The Product Id
+        /// </summary>
+        public required string ProductId { get; set; }
+
+        /// <summary>
+        /// The friendly name of the Product
+        /// </summary>
+        public string ProductName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Quantity of the item on the subscription
+        /// </summary>
+        public long Quantity { get; set; } = 0;
+    }
+
+    /// <summary>
+    /// Custom field completed by the user during Stripe checkout
+    /// </summary>
+    public class StripeCustomFieldModel
+    {
+        /// <summary>
+        /// An ID for the custom field
+        /// </summary>
+        public required string Key { get; set; }
+        /// <summary>
+        /// The value of the custom field
+        /// </summary>
+        public string? Value { get; set; }
+        /// <summary>
+        /// A user-friendly label for the custom field
+        /// </summary>
+        public string Label { get; set; } = string.Empty;
+    }
+}

--- a/Orchestrator.Services/Orchestrator.Services.csproj
+++ b/Orchestrator.Services/Orchestrator.Services.csproj
@@ -6,11 +6,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.19.0" />
-		<PackageReference Include="Microsoft.Extensions.Azure" Version="1.11.0" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.4" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+		<PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.10" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.10" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Stactize.DurableFunctionOrchestratorExample.Tests/Stactize.DurableFunctionOrchestratorExample.Tests.csproj
+++ b/Stactize.DurableFunctionOrchestratorExample.Tests/Stactize.DurableFunctionOrchestratorExample.Tests.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="nunit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="nunit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/Stactize.MultiMarketplaceOrchestratorExample.Tests/MultiMarketplaceOrchestratorTests.cs
+++ b/Stactize.MultiMarketplaceOrchestratorExample.Tests/MultiMarketplaceOrchestratorTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using MultiMarketplaceOrchestratorExample;
 using MultiMarketplaceOrchestratorExample.AWS;
 using MultiMarketplaceOrchestratorExample.Azure;
+using MultiMarketplaceOrchestratorExample.Stripe;
 using Orchestrator.Core;
 using Orchestrator.Core.Contracts;
 using Orchestrator.Core.Models;
@@ -89,6 +90,35 @@ namespace Stactize.MultiMarketplaceOrchestratorExample.Tests
         {
             //Arrange
             var orchestrationActionModel = _fixture.Build<AwsOrchestrationActionModel>()
+                .With(x => x.Event, subscriptionEvent)
+                .Create();
+            var expectedResult = _fixture.Create<OrchestrationResultModel>();
+
+            var context = new Mock<TaskOrchestrationContext>();
+            context.Setup(x => x.GetInput<OrchestrationActionBaseModel>()).Returns(orchestrationActionModel);
+            context.Setup(x => x.CallActivityAsync<OrchestrationResultModel>(taskName, orchestrationActionModel, It.IsAny<TaskOptions>()))
+                .ReturnsAsync(expectedResult);
+
+            //Act
+            var act = () => _sut.RunOrchestrator(context.Object);
+
+            //Assert
+            await act.ShouldNotThrowAsync();
+            context.Verify(x => x.CallActivityAsync<OrchestrationResultModel>(taskName, orchestrationActionModel, It.IsAny<TaskOptions>()),
+                Times.Once);
+            context.Verify(x => x.CallActivityAsync(nameof(MultiMarketplaceOrchestrator.CompleteOrchestratorAction), expectedResult, It.IsAny<TaskOptions>()),
+                Times.Once);
+        }
+
+        [TestCase(SubscriptionEvent.Create, nameof(StripeCreateFunction.StripeCreate))]
+        [TestCase(SubscriptionEvent.Update, nameof(StripeUpdateFunction.StripeUpdate))]
+        [TestCase(SubscriptionEvent.Delete, nameof(StripeDeleteFunction.StripeDelete))]
+        [TestCase(SubscriptionEvent.Reinstate, nameof(StripeReinstateFunction.StripeReinstate))]
+        [TestCase(SubscriptionEvent.Suspend, nameof(StripeSuspendFunction.StripeSuspend))]
+        public async Task RunOrchestrator_WithStripeOrchestrationActionModel_Should_CallCompleteOrchestrator(SubscriptionEvent subscriptionEvent, string taskName)
+        {
+            //Arrange
+            var orchestrationActionModel = _fixture.Build<StripeOrchestrationActionModel>()
                 .With(x => x.Event, subscriptionEvent)
                 .Create();
             var expectedResult = _fixture.Create<OrchestrationResultModel>();

--- a/Stactize.MultiMarketplaceOrchestratorExample.Tests/MultiMarketplaceOrchestratorTests.cs
+++ b/Stactize.MultiMarketplaceOrchestratorExample.Tests/MultiMarketplaceOrchestratorTests.cs
@@ -36,6 +36,7 @@ namespace Stactize.MultiMarketplaceOrchestratorExample.Tests
 
         [TestCase(typeof(AzureOrchestrationActionModel))]
         [TestCase(typeof(AwsOrchestrationActionModel))]
+        [TestCase(typeof(StripeOrchestrationActionModel))]
         public async Task IngressQueueOrchestratorTrigger_Should_ScheduleNewOrchestrationInstance(Type actionType)
         {
             //Arrange

--- a/Stactize.MultiMarketplaceOrchestratorExample.Tests/Stactize.MultiMarketplaceOrchestratorExample.Tests.csproj
+++ b/Stactize.MultiMarketplaceOrchestratorExample.Tests/Stactize.MultiMarketplaceOrchestratorExample.Tests.csproj
@@ -11,13 +11,21 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Stactize.MultiMarketplaceOrchestratorExample.Tests/StripeFunctionTests.cs
+++ b/Stactize.MultiMarketplaceOrchestratorExample.Tests/StripeFunctionTests.cs
@@ -1,0 +1,123 @@
+﻿using AutoFixture;
+using MultiMarketplaceOrchestratorExample.Stripe;
+using Orchestrator.Core;
+using Orchestrator.Core.Models;
+using Shouldly;
+
+namespace Stactize.MultiMarketplaceOrchestratorExample.Tests
+{
+    public class StripeFunctionTests
+    {
+        private readonly Fixture _fixture;
+
+        public StripeFunctionTests()
+        {
+            _fixture = new Fixture();
+        }
+
+        [Test]
+        public void AzureCreate_Should_ReturnOrchestrationResultModel()
+        {
+            //Arrange
+            var action = _fixture.Create<StripeOrchestrationActionModel>();
+
+            //Act
+            var result = StripeCreateFunction.StripeCreate(action);
+
+            //Assert
+            result.ShouldSatisfyAllConditions(
+                () => result.ShouldNotBeNull(),
+                () => result.ShouldBeOfType<OrchestrationResultModel>(),
+                () => result.OperationId.ShouldBe(action.OperationId),
+                () => result.ApplicationId.ShouldBe(action.ApplicationId),
+                () => result.SubscriptionId.ShouldBe(action.SubscriptionId),
+                () => result.TenantId.ShouldBe(action.TenantId),
+                () => result.State.ShouldBe(OrchestrationState.Succeeded)
+            );
+        }
+
+        [Test]
+        public void AzureUpdate_Should_ReturnOrchestrationResultModel()
+        {
+            //Arrange
+            var action = _fixture.Create<StripeOrchestrationActionModel>();
+
+            //Act
+            var result = StripeUpdateFunction.StripeUpdate(action);
+
+            //Assert
+            result.ShouldSatisfyAllConditions(
+                () => result.ShouldNotBeNull(),
+                () => result.ShouldBeOfType<OrchestrationResultModel>(),
+                () => result.ApplicationId.ShouldBe(action.ApplicationId),
+                () => result.OperationId.ShouldBe(action.OperationId),
+                () => result.SubscriptionId.ShouldBe(action.SubscriptionId),
+                () => result.TenantId.ShouldBe(action.TenantId),
+                () => result.State.ShouldBe(OrchestrationState.Succeeded)
+            );
+        }
+
+        [Test]
+        public void AzureSuspend_Should_ReturnOrchestrationResultModel()
+        {
+            //Arrange
+            var action = _fixture.Create<StripeOrchestrationActionModel>();
+
+            //Act
+            var result = StripeSuspendFunction.StripeSuspend(action);
+
+            //Assert
+            result.ShouldSatisfyAllConditions(
+                () => result.ShouldNotBeNull(),
+                () => result.ShouldBeOfType<OrchestrationResultModel>(),
+                () => result.ApplicationId.ShouldBe(action.ApplicationId),
+                () => result.OperationId.ShouldBe(action.OperationId),
+                () => result.SubscriptionId.ShouldBe(action.SubscriptionId),
+                () => result.TenantId.ShouldBe(action.TenantId),
+                () => result.State.ShouldBe(OrchestrationState.Succeeded)
+            );
+        }
+
+        [Test]
+        public void AzureReinstate_Should_ReturnOrchestrationResultModel()
+        {
+            //Arrange
+            var action = _fixture.Create<StripeOrchestrationActionModel>();
+
+            //Act
+            var result = StripeReinstateFunction.StripeReinstate(action);
+
+            //Assert
+            result.ShouldSatisfyAllConditions(
+                () => result.ShouldNotBeNull(),
+                () => result.ShouldBeOfType<OrchestrationResultModel>(),
+                () => result.ApplicationId.ShouldBe(action.ApplicationId),
+                () => result.OperationId.ShouldBe(action.OperationId),
+                () => result.SubscriptionId.ShouldBe(action.SubscriptionId),
+                () => result.TenantId.ShouldBe(action.TenantId),
+                () => result.State.ShouldBe(OrchestrationState.Succeeded)
+            );
+        }
+
+        [Test]
+        public void AzureDelete_Should_ReturnOrchestrationResultModel()
+        {
+            //Arrange
+            var action = _fixture.Create<StripeOrchestrationActionModel>();
+
+            //Act
+            var result = StripeDeleteFunction.StripeDelete(action);
+
+            //Assert
+            result.ShouldSatisfyAllConditions(
+                () => result.ShouldNotBeNull(),
+                () => result.ShouldBeOfType<OrchestrationResultModel>(),
+                () => result.ApplicationId.ShouldBe(action.ApplicationId),
+                () => result.OperationId.ShouldBe(action.OperationId),
+                () => result.SubscriptionId.ShouldBe(action.SubscriptionId),
+                () => result.TenantId.ShouldBe(action.TenantId),
+                () => result.State.ShouldBe(OrchestrationState.Succeeded)
+            );
+        }
+    }
+}

--- a/Stactize.MultiMarketplaceOrchestratorExample.Tests/StripeFunctionTests.cs
+++ b/Stactize.MultiMarketplaceOrchestratorExample.Tests/StripeFunctionTests.cs
@@ -16,7 +16,7 @@ namespace Stactize.MultiMarketplaceOrchestratorExample.Tests
         }
 
         [Test]
-        public void AzureCreate_Should_ReturnOrchestrationResultModel()
+        public void StripeCreate_Should_ReturnOrchestrationResultModel()
         {
             //Arrange
             var action = _fixture.Create<StripeOrchestrationActionModel>();
@@ -37,7 +37,7 @@ namespace Stactize.MultiMarketplaceOrchestratorExample.Tests
         }
 
         [Test]
-        public void AzureUpdate_Should_ReturnOrchestrationResultModel()
+        public void StripeUpdate_Should_ReturnOrchestrationResultModel()
         {
             //Arrange
             var action = _fixture.Create<StripeOrchestrationActionModel>();
@@ -58,7 +58,7 @@ namespace Stactize.MultiMarketplaceOrchestratorExample.Tests
         }
 
         [Test]
-        public void AzureSuspend_Should_ReturnOrchestrationResultModel()
+        public void StripeSuspend_Should_ReturnOrchestrationResultModel()
         {
             //Arrange
             var action = _fixture.Create<StripeOrchestrationActionModel>();
@@ -79,7 +79,7 @@ namespace Stactize.MultiMarketplaceOrchestratorExample.Tests
         }
 
         [Test]
-        public void AzureReinstate_Should_ReturnOrchestrationResultModel()
+        public void StripeReinstate_Should_ReturnOrchestrationResultModel()
         {
             //Arrange
             var action = _fixture.Create<StripeOrchestrationActionModel>();
@@ -100,7 +100,7 @@ namespace Stactize.MultiMarketplaceOrchestratorExample.Tests
         }
 
         [Test]
-        public void AzureDelete_Should_ReturnOrchestrationResultModel()
+        public void StripeDelete_Should_ReturnOrchestrationResultModel()
         {
             //Arrange
             var action = _fixture.Create<StripeOrchestrationActionModel>();


### PR DESCRIPTION
###Overview:
Updated MultiMarketplaceOrchestratorExample with examples of Stripe orchestration

- Added Stripe to Marketplace enum
- Added `StripeOrchestrationActionModel` with Stripe-specific parameters
- Updated `OrchestrationActionModelConverter` to convert `StripeOrchestrationActionModel`
- Added stub implementations for Stripe event handlers

###Reason: 
Stactize to implement Stripe integration

###Unit tests:
Added unit tests for Stripe events
<img width="504" height="522" alt="image" src="https://github.com/user-attachments/assets/e27ca7bb-46a9-48dc-9567-26619ddeea0e" />

###Documentation: 
Github wiki will be updated with Stripe details
