### PR TITLE
Add Google Cloud Marketplace support to MultiMarketplaceOrchestratorExample

### DIFF
--- a/DurableFunctionOrchestratorExample/DurableFunctionOrchestratorExample.csproj
+++ b/DurableFunctionOrchestratorExample/DurableFunctionOrchestratorExample.csproj
@@ -6,13 +6,13 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.14.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="5.24.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.50.0" />
   </ItemGroup>
   <ItemGroup>

--- a/MultiMarketplaceOrchestratorExample/Google/GoogleCreateFunction.cs
+++ b/MultiMarketplaceOrchestratorExample/Google/GoogleCreateFunction.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Azure.Functions.Worker;
+using Orchestrator.Core;
+using Orchestrator.Core.Models;
+
+namespace MultiMarketplaceOrchestratorExample.Google
+{
+    public static class GoogleCreateFunction
+    {
+        [Function(nameof(GoogleCreate))]
+        public static OrchestrationResultModel GoogleCreate([ActivityTrigger] GoogleOrchestrationActionModel orchestrationAction)
+        {
+            //Call your orchestration functions here to create your instances and generate a url for a user to log in to
+            return orchestrationAction.CreateSuccessResult(new Uri("https://mywebsite.com"));
+        }
+    }
+}

--- a/MultiMarketplaceOrchestratorExample/Google/GoogleDeleteFunction.cs
+++ b/MultiMarketplaceOrchestratorExample/Google/GoogleDeleteFunction.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Azure.Functions.Worker;
+using Orchestrator.Core;
+using Orchestrator.Core.Models;
+
+namespace MultiMarketplaceOrchestratorExample.Google
+{
+    public static class GoogleDeleteFunction
+    {
+        [Function(nameof(GoogleDelete))]
+        public static OrchestrationResultModel GoogleDelete([ActivityTrigger] GoogleOrchestrationActionModel orchestrationAction)
+        {
+            //Call your orchestration functions here to remove any instances and user logins
+            return orchestrationAction.CreateSuccessResult(new Uri("about:blank"));
+        }
+    }
+}

--- a/MultiMarketplaceOrchestratorExample/Google/GoogleUpdateFunction.cs
+++ b/MultiMarketplaceOrchestratorExample/Google/GoogleUpdateFunction.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Azure.Functions.Worker;
+using Orchestrator.Core;
+using Orchestrator.Core.Models;
+
+namespace MultiMarketplaceOrchestratorExample.Google
+{
+    public static class GoogleUpdateFunction
+    {
+        [Function(nameof(GoogleUpdate))]
+        public static OrchestrationResultModel GoogleUpdate([ActivityTrigger] GoogleOrchestrationActionModel orchestrationAction)
+        {
+            //Call your orchestration functions here to update any instances and send potentially new url
+            return orchestrationAction.CreateSuccessResult(new Uri("https://mywebsite.com"));
+        }
+    }
+}

--- a/MultiMarketplaceOrchestratorExample/MultiMarketplaceOrchestrator.cs
+++ b/MultiMarketplaceOrchestratorExample/MultiMarketplaceOrchestrator.cs
@@ -4,6 +4,7 @@ using Microsoft.DurableTask.Client;
 using Microsoft.Extensions.Logging;
 using MultiMarketplaceOrchestratorExample.AWS;
 using MultiMarketplaceOrchestratorExample.Azure;
+using MultiMarketplaceOrchestratorExample.Google;
 using MultiMarketplaceOrchestratorExample.Stripe;
 using Orchestrator.Core;
 using Orchestrator.Core.Contracts;
@@ -64,6 +65,10 @@ namespace MultiMarketplaceOrchestratorExample
                     (Marketplace.Stripe, SubscriptionEvent.Suspend) => nameof(StripeSuspendFunction.StripeSuspend),
                     (Marketplace.Stripe, SubscriptionEvent.Reinstate) => nameof(StripeReinstateFunction.StripeReinstate),
                     (Marketplace.Stripe, SubscriptionEvent.Delete) => nameof(StripeDeleteFunction.StripeDelete),
+
+                    (Marketplace.Google, SubscriptionEvent.Create) => nameof(GoogleCreateFunction.GoogleCreate),
+                    (Marketplace.Google, SubscriptionEvent.Update) => nameof(GoogleUpdateFunction.GoogleUpdate),
+                    (Marketplace.Google, SubscriptionEvent.Delete) => nameof(GoogleDeleteFunction.GoogleDelete),
 
                     _ => throw new NotImplementedException("No handler for orchestration event.")
                 };

--- a/MultiMarketplaceOrchestratorExample/MultiMarketplaceOrchestratorExample.csproj
+++ b/MultiMarketplaceOrchestratorExample/MultiMarketplaceOrchestratorExample.csproj
@@ -11,8 +11,8 @@
     <!-- Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4. -->
     <!-- <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" /> -->
     <!-- <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" /> -->
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.14.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.16.5" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />

--- a/Orchestrator.Core/Converters/OrchestrationActionModelConverter.cs
+++ b/Orchestrator.Core/Converters/OrchestrationActionModelConverter.cs
@@ -28,6 +28,7 @@ namespace Orchestrator.Core.Converters
                 "Azure" => JsonSerializer.Deserialize<AzureOrchestrationActionModel>(jsonDoc, options),
                 "Aws" => JsonSerializer.Deserialize<AwsOrchestrationActionModel>(jsonDoc, options),
                 "Stripe" => JsonSerializer.Deserialize<StripeOrchestrationActionModel>(jsonDoc, options),
+                "Google" => JsonSerializer.Deserialize<GoogleOrchestrationActionModel>(jsonDoc, options),
                 _ => throw new JsonException($"Unknown OriginatingMarketplace: {originatingMarketplace}")
             };
 

--- a/Orchestrator.Core/Models/GoogleOrchestrationActionModel.cs
+++ b/Orchestrator.Core/Models/GoogleOrchestrationActionModel.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Orchestrator.Core.Models
+{
+    /// <summary>
+    ///  Orchestration Action Model for Google Cloud Marketplace events
+    /// </summary>
+    public class GoogleOrchestrationActionModel : OrchestrationActionBaseModel
+    {
+        /// <summary>
+        /// Override for Google Cloud Marketplace orchestration actions
+        /// </summary>
+        public override Marketplace OriginatingMarketplace => Marketplace.Google;
+        /// <summary>
+        /// The Google Cloud Marketplace product ID for the subscription/entitlement
+        /// </summary>
+        public string ProductId { get; set; } = string.Empty;
+        /// <summary>
+        /// The Google Cloud Marketplace billing plan for the subscription/entitlement
+        /// </summary>
+        public string PlanId { get; set; } = string.Empty;
+        /// <summary>
+        /// The Google Cloud Marketplace order ID for the subscription/entitlement
+        /// </summary>
+        public string OrderId { get; set; } = string.Empty;
+    }
+}

--- a/Orchestrator.Core/Models/GoogleOrchestrationActionModel.cs
+++ b/Orchestrator.Core/Models/GoogleOrchestrationActionModel.cs
@@ -16,14 +16,14 @@ namespace Orchestrator.Core.Models
         /// <summary>
         /// The Google Cloud Marketplace product ID for the subscription/entitlement
         /// </summary>
-        public string ProductId { get; set; } = string.Empty;
+        public required string ProductId { get; set; }
         /// <summary>
         /// The Google Cloud Marketplace billing plan for the subscription/entitlement
         /// </summary>
-        public string PlanId { get; set; } = string.Empty;
+        public required string PlanId { get; set; }
         /// <summary>
         /// The Google Cloud Marketplace order ID for the subscription/entitlement
         /// </summary>
-        public string OrderId { get; set; } = string.Empty;
+        public required string OrderId { get; set; }
     }
 }

--- a/Orchestrator.Core/Models/OrchestrationActionBaseModel.cs
+++ b/Orchestrator.Core/Models/OrchestrationActionBaseModel.cs
@@ -104,6 +104,7 @@ namespace Orchestrator.Core.Models
     {
         Azure,
         Aws,
-        Stripe
+        Stripe,
+        Google
     }
 }

--- a/Orchestrator.Services/Orchestrator.Services.csproj
+++ b/Orchestrator.Services/Orchestrator.Services.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.13.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.14.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>

--- a/Stactize.DurableFunctionOrchestratorExample.Tests/Stactize.DurableFunctionOrchestratorExample.Tests.csproj
+++ b/Stactize.DurableFunctionOrchestratorExample.Tests/Stactize.DurableFunctionOrchestratorExample.Tests.csproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
-  </PropertyGroup>
+   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="nunit" Version="4.4.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="nunit" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Stactize.MultiMarketplaceOrchestratorExample.Tests/GoogleFunctionTests.cs
+++ b/Stactize.MultiMarketplaceOrchestratorExample.Tests/GoogleFunctionTests.cs
@@ -1,0 +1,81 @@
+﻿using AutoFixture;
+using MultiMarketplaceOrchestratorExample.Google;
+using Orchestrator.Core;
+using Orchestrator.Core.Models;
+using Shouldly;
+
+namespace Stactize.MultiMarketplaceOrchestratorExample.Tests
+{
+    public class GoogleFunctionTests
+    {
+        private readonly Fixture _fixture;
+
+        public GoogleFunctionTests()
+        {
+            _fixture = new Fixture();
+        }
+
+        [Test]
+        public void GoogleCreate_Should_ReturnOrchestrationResultModel()
+        {
+            //Arrange
+            var action = _fixture.Create<GoogleOrchestrationActionModel>();
+
+            //Act
+            var result = GoogleCreateFunction.GoogleCreate(action);
+
+            //Assert
+            result.ShouldSatisfyAllConditions(
+                () => result.ShouldNotBeNull(),
+                () => result.ShouldBeOfType<OrchestrationResultModel>(),
+                () => result.OperationId.ShouldBe(action.OperationId),
+                () => result.ApplicationId.ShouldBe(action.ApplicationId),
+                () => result.SubscriptionId.ShouldBe(action.SubscriptionId),
+                () => result.TenantId.ShouldBe(action.TenantId),
+                () => result.State.ShouldBe(OrchestrationState.Succeeded)
+            );
+        }
+
+        [Test]
+        public void GoogleUpdate_Should_ReturnOrchestrationResultModel()
+        {
+            //Arrange
+            var action = _fixture.Create<GoogleOrchestrationActionModel>();
+
+            //Act
+            var result = GoogleUpdateFunction.GoogleUpdate(action);
+
+            //Assert
+            result.ShouldSatisfyAllConditions(
+                () => result.ShouldNotBeNull(),
+                () => result.ShouldBeOfType<OrchestrationResultModel>(),
+                () => result.ApplicationId.ShouldBe(action.ApplicationId),
+                () => result.OperationId.ShouldBe(action.OperationId),
+                () => result.SubscriptionId.ShouldBe(action.SubscriptionId),
+                () => result.TenantId.ShouldBe(action.TenantId),
+                () => result.State.ShouldBe(OrchestrationState.Succeeded)
+            );
+        }
+
+        [Test]
+        public void GoogleDelete_Should_ReturnOrchestrationResultModel()
+        {
+            //Arrange
+            var action = _fixture.Create<GoogleOrchestrationActionModel>();
+
+            //Act
+            var result = GoogleDeleteFunction.GoogleDelete(action);
+
+            //Assert
+            result.ShouldSatisfyAllConditions(
+                () => result.ShouldNotBeNull(),
+                () => result.ShouldBeOfType<OrchestrationResultModel>(),
+                () => result.ApplicationId.ShouldBe(action.ApplicationId),
+                () => result.OperationId.ShouldBe(action.OperationId),
+                () => result.SubscriptionId.ShouldBe(action.SubscriptionId),
+                () => result.TenantId.ShouldBe(action.TenantId),
+                () => result.State.ShouldBe(OrchestrationState.Succeeded)
+            );
+        }
+    }
+}

--- a/Stactize.MultiMarketplaceOrchestratorExample.Tests/MultiMarketplaceOrchestratorTests.cs
+++ b/Stactize.MultiMarketplaceOrchestratorExample.Tests/MultiMarketplaceOrchestratorTests.cs
@@ -7,6 +7,7 @@ using Moq;
 using MultiMarketplaceOrchestratorExample;
 using MultiMarketplaceOrchestratorExample.AWS;
 using MultiMarketplaceOrchestratorExample.Azure;
+using MultiMarketplaceOrchestratorExample.Google;
 using MultiMarketplaceOrchestratorExample.Stripe;
 using Orchestrator.Core;
 using Orchestrator.Core.Contracts;
@@ -120,6 +121,33 @@ namespace Stactize.MultiMarketplaceOrchestratorExample.Tests
         {
             //Arrange
             var orchestrationActionModel = _fixture.Build<StripeOrchestrationActionModel>()
+                .With(x => x.Event, subscriptionEvent)
+                .Create();
+            var expectedResult = _fixture.Create<OrchestrationResultModel>();
+
+            var context = new Mock<TaskOrchestrationContext>();
+            context.Setup(x => x.GetInput<OrchestrationActionBaseModel>()).Returns(orchestrationActionModel);
+            context.Setup(x => x.CallActivityAsync<OrchestrationResultModel>(taskName, orchestrationActionModel, It.IsAny<TaskOptions>()))
+                .ReturnsAsync(expectedResult);
+
+            //Act
+            var act = () => _sut.RunOrchestrator(context.Object);
+
+            //Assert
+            await act.ShouldNotThrowAsync();
+            context.Verify(x => x.CallActivityAsync<OrchestrationResultModel>(taskName, orchestrationActionModel, It.IsAny<TaskOptions>()),
+                Times.Once);
+            context.Verify(x => x.CallActivityAsync(nameof(MultiMarketplaceOrchestrator.CompleteOrchestratorAction), expectedResult, It.IsAny<TaskOptions>()),
+                Times.Once);
+        }
+
+        [TestCase(SubscriptionEvent.Create, nameof(GoogleCreateFunction.GoogleCreate))]
+        [TestCase(SubscriptionEvent.Update, nameof(GoogleUpdateFunction.GoogleUpdate))]
+        [TestCase(SubscriptionEvent.Delete, nameof(GoogleDeleteFunction.GoogleDelete))]
+        public async Task RunOrchestrator_WithGoogleOrchestrationActionModel_Should_CallCompleteOrchestrator(SubscriptionEvent subscriptionEvent, string taskName)
+        {
+            //Arrange
+            var orchestrationActionModel = _fixture.Build<GoogleOrchestrationActionModel>()
                 .With(x => x.Event, subscriptionEvent)
                 .Create();
             var expectedResult = _fixture.Create<OrchestrationResultModel>();

--- a/Stactize.MultiMarketplaceOrchestratorExample.Tests/Stactize.MultiMarketplaceOrchestratorExample.Tests.csproj
+++ b/Stactize.MultiMarketplaceOrchestratorExample.Tests/Stactize.MultiMarketplaceOrchestratorExample.Tests.csproj
@@ -5,21 +5,21 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
+    </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NUnit" Version="4.4.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+    <PackageReference Include="NUnit" Version="4.6.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Overview:
Added Google Cloud Marketplace support to the MultiMarketplaceOrchestratorExample with examples of Google orchestration

- Introduce GoogleOrchestrationActionModel for Google Cloud Marketplace events
- Added GoogleOrchestrationActionModel with Google-specific properties
- Updated OrchestrationActionModelConverter to convert GoogleOrchestrationActionModel
- Added Google to Marketplace enum
- Added Google stub implementations event handlers

### Reason: 
Google Cloud Marketplace to be added as a marketplace platform on Stactize

### Screenshots: N/A

### Link to designs: N/A

### Unit tests:
Added tests for Google implementation. All new tests + existing ones pass
<img width="710" height="459" alt="image" src="https://github.com/user-attachments/assets/fb7ef6ce-4549-4021-aef7-da90d932f2ea" />

### Integration tests: N/A

### Documentation:
Wiki to be updated with Google implementation and examples
